### PR TITLE
Add "Away Mode" switch service to MasterControllerAccessory

### DIFF
--- a/src/masterControllerAccessory.ts
+++ b/src/masterControllerAccessory.ts
@@ -107,6 +107,7 @@ export class MasterControllerAccessory {
     this.hvacService.updateCharacteristic(this.platform.Characteristic.CoolingThresholdTemperature, this.getCoolingThresholdTemperature());
     this.hvacService.updateCharacteristic(this.platform.Characteristic.RotationSpeed, this.getFanMode());
     this.humidityService.updateCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity, this.getHumidity());
+    this.awayModeSwitchService.updateCharacteristic(this.platform.Characteristic.On, this.getAwayMode());
   }
 
   checkHvacComms() {

--- a/src/masterControllerAccessory.ts
+++ b/src/masterControllerAccessory.ts
@@ -5,6 +5,7 @@ import { ActronQuePlatform } from './platform';
 export class MasterControllerAccessory {
   private hvacService: Service;
   private humidityService: Service;
+  private awayModeSwitchService: Service;
 
   constructor(
     private readonly platform: ActronQuePlatform,
@@ -68,6 +69,17 @@ export class MasterControllerAccessory {
       .onSet(this.setFanMode.bind(this))
       .onGet(this.getFanMode.bind(this));
 
+    // Get or create the away mode switch service.
+    this.awayModeSwitchService = this.accessory.getService(this.platform.Service.Switch)
+      || this.accessory.addService(this.platform.Service.Switch);
+
+    this.awayModeSwitchService.setCharacteristic(this.platform.Characteristic.Name, 'Away Mode');
+
+    // register handlers for away mode control
+    this.awayModeSwitchService.getCharacteristic(this.platform.Characteristic.On)
+      .onSet(this.setAwayMode.bind(this))
+      .onGet(this.getAwayMode.bind(this));
+
     // Set the refresh interval for continuous device characteristic updates.
     setInterval(() => this.hardUpdateDeviceCharacteristics(), this.platform.hardRefreshInterval);
     setInterval(() => this.softUpdateDeviceCharacteristics(), this.platform.softRefreshInterval);
@@ -125,6 +137,21 @@ export class MasterControllerAccessory {
   getPowerState(): CharacteristicValue {
     const powerState = (this.platform.hvacInstance.powerState === PowerState.ON) ? 1 : 0;
     return powerState;
+  }
+
+  getAwayMode(): CharacteristicValue {
+    const awayMode = this.platform.hvacInstance.awayMode ? 1 : 0;
+    return awayMode;
+  }
+
+  async setAwayMode(value: CharacteristicValue) {
+    this.checkHvacComms();
+    if (value) {
+      await this.platform.hvacInstance.setAwayModeOn();
+    } else {
+      await this.platform.hvacInstance.setAwayModeOff();
+    }
+    this.platform.log.debug('Set Master Away Mode -> ', value);
   }
 
   getCurrentCompressorMode(): CharacteristicValue {


### PR DESCRIPTION
This pull request implements an Away Mode switch in the MasterControllerAccessory. The Away Mode switch allows users to set up automation within HomeKit to toggle Away Mode when the last person leaves home and turn it off when someone arrives.
