### PR TITLE
Serialize and debounce outbound commands to fix dropped changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ If you are not using the Homebridge config UI, you can add the following to your
         "zonesPushMaster": true,
         "zonesAsHeaterCoolers": false,
         "refreshInterval": 60,
+        "commandDebounceMs": 500,
         "deviceSerial": "",
         "maxCoolingTemp": 32,
         "minCoolingTemp": 20,
@@ -75,6 +76,12 @@ If you are not using the Homebridge config UI, you can add the following to your
     }
 ]
 ```
+
+## Command Debouncing
+
+When you make several changes in quick succession — dragging a temperature slider, toggling several zones on/off, or turning the unit on/off right after a zone change — the plugin waits briefly for you to finish and then sends a single, consolidated command. This prevents the changes from racing each other on the Neo cloud, which previously could leave only the last change applied or land a temperature somewhere between the start and target value.
+
+`commandDebounceMs` (default `500`) controls how long, in milliseconds, the plugin waits after your last change before sending. Lower values feel snappier; higher values coalesce more aggressively for very jittery bursts. Commands are also serialised, so they always apply to the unit in the order you made them.
 
 ## Controlling Zone Temperature Settings
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -58,6 +58,13 @@
         "required": false,
         "default": 60
       },
+      "commandDebounceMs": {
+        "title": "Command Debounce Window (ms)",
+        "description": "How long to wait after your last change before sending it to the AC. Rapid changes (dragging a temperature slider, toggling several zones) are coalesced into a single command so they all apply. Lower feels snappier; higher coalesces more aggressively. Default 500.",
+        "type": "integer",
+        "required": false,
+        "default": 500
+      },
       "deviceSerial": {
         "title": "Neo System Serial Number",
         "description": "Only required if you have multiple systems in your Neo cloud account.",

--- a/docs/superpowers/specs/2026-07-19-command-pipeline-design.md
+++ b/docs/superpowers/specs/2026-07-19-command-pipeline-design.md
@@ -1,0 +1,195 @@
+# Serialized + Coalesced Command Pipeline — Design
+
+**Date:** 2026-07-19
+**Status:** Approved for planning
+
+## Problem
+
+Rapid successive changes from HomeKit do not all apply:
+
+- Toggling several zones on/off in quick succession leaves only one (or some) applied.
+- Dragging a temperature slider lands on a value *between* the start and the intended target.
+- Turning the unit on/off right after a zone change applies inconsistently.
+
+### Root causes
+
+There are **two distinct mechanisms**, not one.
+
+**1. Read-modify-write race on zones.** Every zone command rebuilds the entire
+`EnabledZones` array. In `queApi.ts` `runCommand()` fetches fresh cloud state
+(`getZoneStatuses()`), copies the array, flips a single index, then POSTs the whole
+array. The Neo cloud is eventually consistent, so concurrent zone commands each read
+stale state and clobber each other:
+
+```
+Cmd A (zone 0): reads [F,F,F] -> sends [T,F,F]
+Cmd B (zone 1): reads [F,F,F] -> sends [F,T,F]   (A not yet reflected)
+Cmd C (zone 2): reads [F,F,F] -> sends [F,F,T]
+Final: [F,F,T]  -- only the last toggle survives
+```
+
+Because the toggles come from three different accessories, debouncing a single switch
+cannot fix this. The array must be built from **local authoritative state**, and sends
+must be **serialized**.
+
+**2. Unordered concurrent sends.** HomeKit fires an `onSet` for every intermediate
+slider value. Each becomes its own GET + POST with no ordering guarantee, so whichever
+the cloud processes last wins — often not the final value. The same applies to any burst
+of unrelated commands (mode, then temp, then power). This is a classic debounce problem.
+
+## Goals
+
+- Rapid multi-zone toggles all apply.
+- Temperature slider lands on the final value.
+- Bursts of mode / power / fan changes settle on the last intent.
+- Fewer redundant API calls (one send per settled burst; no per-command status GET).
+
+## Non-goals
+
+- Changing the periodic refresh (`getStatus`) cadence or reconciliation model.
+- Reworking auth/token handling or the retry logic in `manageApiRequest`.
+- Offline queueing / persistence of commands across Homebridge restarts.
+
+## Design
+
+Two coordinated mechanisms.
+
+### A. Serial command queue (in `QueApi`)
+
+A private promise-chain ensures only one API request is in flight at a time and that
+requests execute in strict enqueue order.
+
+```ts
+private commandChain: Promise<unknown> = Promise.resolve();
+
+private enqueue<T>(task: () => Promise<T>): Promise<T> {
+  const run = this.commandChain.then(task, task); // run regardless of prior outcome
+  this.commandChain = run.catch(() => undefined); // an error must not wedge the chain
+  return run;
+}
+```
+
+All command sends in `runCommand()` go through `enqueue()`. This removes the
+concurrency that makes ordering nondeterministic and makes local zone state safe to
+mutate without races. It does **not** apply to `getStatus()` reads, which remain
+independent.
+
+### B. Debounce + coalesce layer (`src/debouncer.ts`, new)
+
+A generic, pure, testable keyed trailing-edge debouncer. No HVAC knowledge lives here —
+policy (keys, values, coalescing) lives in the HVAC layer.
+
+Behaviour:
+
+- `schedule(key, action, delayMs)` — (re)start the timer for `key`; when it fires, run
+  the latest `action` registered for that key. A new call for the same key before firing
+  replaces the pending action and restarts the timer.
+- Distinct keys are independent timers.
+- An error thrown by an `action` is caught/logged and must not prevent future scheduling
+  for that key.
+- A `flush(key?)` / `cancelAll()` affordance for clean shutdown and tests.
+
+Two usage flavours in the HVAC layer:
+
+- **Last-value-wins** — setpoints, mode, power, fan, away, quiet. Key encodes the target
+  (`master:cool`, `master:heat`, `zone:3:heat`, `power`, `mode`, `fanMode`,
+  `awayMode`, `quietMode`). Each `set*` overwrites the pending action with the newest
+  value; only the final value is sent.
+- **Coalesced zones** — all zone enable/disable share one key (`zones`) and mutate the
+  shared local desired array (below). The single flushed action sends the whole array
+  once via `SET_ENABLED_ZONES`.
+
+Default window **500 ms**, configurable via `commandDebounceMs`.
+
+### C. Local authoritative `enabledZones` (kills the RMW race)
+
+`QueApi` holds `enabledZones: boolean[]`:
+
+- Seeded and reconciled by `getStatus()` (which already parses
+  `UserAirconSettings.EnabledZones`).
+- Mutated locally by zone sends before flushing.
+- Used to build zone commands — **no per-command GET**.
+
+`getZoneStatuses()` (and its `// TODO - Shouldn't need to make this call` at
+`queApi.ts:423`) is **deleted**. In `queCommands.ts`, `ZONE_ENABLE` and `ZONE_DISABLE`
+collapse into a single `SET_ENABLED_ZONES(array)` builder that emits
+`UserAirconSettings.EnabledZones`.
+
+### D. Optimistic state + reconcile
+
+Because `onSet` handlers now return before the debounced send fires, each `set*` method
+in `HvacUnit` / `HvacZone`:
+
+1. Updates its local state immediately (HomeKit getters reflect intent),
+2. Schedules the debounced/coalesced send through the debouncer → serial queue,
+3. Returns the optimistic value.
+
+On send failure (`CommandResult.FAILURE` or `API_ERROR`), it triggers `getStatus()` to
+reconcile true state back to HomeKit — the same recovery path the code already uses on
+failure today. The periodic hard refresh remains the backstop for drift.
+
+## Components
+
+| File | Change |
+|---|---|
+| `src/debouncer.ts` | **New.** Generic keyed trailing-edge debounce + coalesce. Pure timing logic. |
+| `src/queApi.ts` | Add serial promise-chain wrapping all sends; add local `enabledZones`; delete `getZoneStatuses()`; `runCommand()` builds zone commands from local state. |
+| `src/queCommands.ts` | Replace `ZONE_ENABLE` / `ZONE_DISABLE` with `SET_ENABLED_ZONES(array)`. |
+| `src/hvac.ts` | Route setpoint / mode / power / fan / away / quiet sends through the debouncer; optimistic update + reconcile-on-failure. |
+| `src/hvacZone.ts` | Route zone enable/disable + zone setpoints through the debouncer (zones coalesced on key `zones`, mutating shared local array). |
+| `src/platform.ts` | Read `commandDebounceMs` (default 500) and pass to `HvacUnit`. |
+| `config.schema.json` | Add `commandDebounceMs` field (default 500). |
+| `README.md` | Document `commandDebounceMs`. |
+
+Wiring of the debouncer instance: created once (owned by `HvacUnit`, constructed with the
+configured window) and shared by the master unit and all zone instances so the `zones`
+key coalesces across accessories.
+
+## Data flow
+
+**Drag master cool slider:**
+`onSet` ×N → optimistic temp set + reschedule key `master:cool` → 500 ms idle →
+one `COOL_SET_POINT(final)` → serial queue → single POST.
+
+**Toggle 3 zones fast:**
+`onSet` ×3 (3 accessories) → each mutates shared `enabledZones` + reschedules key
+`zones` → 500 ms idle → one `SET_ENABLED_ZONES([T,T,T])` → serial queue → single POST.
+All three stick.
+
+**Unit off right after a zone change:**
+Zone flush on key `zones` and power on key `power` fire independently but both pass
+through the serial queue, so they apply in order without interleaving.
+
+## Error handling
+
+- Serial chain catches errors so one failed send never wedges the queue.
+- Debouncer catches errors thrown by actions so a failed flush never blocks future
+  scheduling for that key.
+- Send failure → optimistic state is corrected by a `getStatus()` reconcile.
+- Existing `manageApiRequest` retry/backoff and token refresh are unchanged.
+
+## Testing
+
+- `debouncer.test.ts` (fake timers): burst → one call; latest action wins; distinct keys
+  isolated; action error does not wedge the key; `flush`/`cancelAll` behave.
+- Serial queue: strict ordering; one-at-a-time (no overlap); an error does not break the
+  chain for subsequent commands.
+- Zone coalescing: three toggles across zones → one `SET_ENABLED_ZONES` with all bits
+  set; **no** `getZoneStatuses` call; local array seeded from `getStatus`.
+- Setpoint debounce: N values on one key → only the last is sent.
+- Optimistic + reconcile: getter returns intended value immediately; a failed send
+  triggers a `getStatus()` reconcile.
+- Update existing `queApi.test.ts`, `hvac.test.ts`, `hvacZone.test.ts` for the removed
+  GET, the new `SET_ENABLED_ZONES` shape, and the debounced/optimistic behaviour.
+
+## Config
+
+`commandDebounceMs` — integer, default `500`. Quiet window before a settled burst is
+sent. Lower = snappier but less coalescing; higher = safer under very jittery bursts but
+a touch laggier on a single deliberate change.
+
+## Open questions
+
+None outstanding. `getZoneStatuses()` removal, the `ZONE_ENABLE/DISABLE` → single
+`SET_ENABLED_ZONES` collapse, and extending debounce/optimistic handling to
+modes/power/fan were confirmed during brainstorming.

--- a/src/debouncer.test.ts
+++ b/src/debouncer.test.ts
@@ -1,0 +1,120 @@
+import { Debouncer } from './debouncer';
+
+describe('Debouncer', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('runs the action once after the quiet window', async () => {
+    const debouncer = new Debouncer(500);
+    const action = jest.fn().mockResolvedValue('done');
+
+    const promise = debouncer.schedule('key', action);
+    expect(action).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(500);
+    await expect(promise).resolves.toBe('done');
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
+  it('collapses a burst on the same key into a single run of the latest action', async () => {
+    const debouncer = new Debouncer(500);
+    const first = jest.fn().mockResolvedValue(1);
+    const second = jest.fn().mockResolvedValue(2);
+    const third = jest.fn().mockResolvedValue(3);
+
+    const p1 = debouncer.schedule('key', first);
+    jest.advanceTimersByTime(200);
+    const p2 = debouncer.schedule('key', second);
+    jest.advanceTimersByTime(200);
+    const p3 = debouncer.schedule('key', third);
+
+    jest.advanceTimersByTime(500);
+    await Promise.resolve();
+
+    // Only the last action runs...
+    expect(first).not.toHaveBeenCalled();
+    expect(second).not.toHaveBeenCalled();
+    expect(third).toHaveBeenCalledTimes(1);
+    // ...and every caller shares its result.
+    await expect(p1).resolves.toBe(3);
+    await expect(p2).resolves.toBe(3);
+    await expect(p3).resolves.toBe(3);
+  });
+
+  it('keeps distinct keys independent', async () => {
+    const debouncer = new Debouncer(500);
+    const a = jest.fn().mockResolvedValue('a');
+    const b = jest.fn().mockResolvedValue('b');
+
+    const pa = debouncer.schedule('a', a);
+    const pb = debouncer.schedule('b', b);
+
+    jest.advanceTimersByTime(500);
+    await Promise.all([pa, pb]);
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    await expect(pa).resolves.toBe('a');
+    await expect(pb).resolves.toBe('b');
+  });
+
+  it('reports pending state and clears it after firing', async () => {
+    const debouncer = new Debouncer(500);
+    const promise = debouncer.schedule('key', jest.fn().mockResolvedValue(undefined));
+
+    expect(debouncer.isPending('key')).toBe(true);
+    expect(debouncer.isPending('other')).toBe(false);
+
+    jest.advanceTimersByTime(500);
+    await promise;
+
+    expect(debouncer.isPending('key')).toBe(false);
+  });
+
+  it('rejects the shared promise when the action throws, without wedging the key', async () => {
+    const debouncer = new Debouncer(500);
+    const failing = jest.fn().mockRejectedValue(new Error('boom'));
+
+    const p1 = debouncer.schedule('key', failing);
+    jest.advanceTimersByTime(500);
+    await expect(p1).rejects.toThrow('boom');
+
+    // The key is free again and can be rescheduled.
+    expect(debouncer.isPending('key')).toBe(false);
+    const ok = jest.fn().mockResolvedValue('ok');
+    const p2 = debouncer.schedule('key', ok);
+    jest.advanceTimersByTime(500);
+    await expect(p2).resolves.toBe('ok');
+  });
+
+  it('flush runs the pending action immediately', async () => {
+    const debouncer = new Debouncer(500);
+    const action = jest.fn().mockResolvedValue('flushed');
+
+    const promise = debouncer.schedule('key', action);
+    await debouncer.flush('key');
+
+    expect(action).toHaveBeenCalledTimes(1);
+    await expect(promise).resolves.toBe('flushed');
+    expect(debouncer.isPending('key')).toBe(false);
+  });
+
+  it('cancelAll rejects pending promises and clears timers', async () => {
+    const debouncer = new Debouncer(500);
+    const action = jest.fn().mockResolvedValue('never');
+    const promise = debouncer.schedule('key', action);
+
+    debouncer.cancelAll();
+
+    await expect(promise).rejects.toThrow('cancelled');
+    expect(debouncer.isPending('key')).toBe(false);
+    jest.advanceTimersByTime(500);
+    expect(action).not.toHaveBeenCalled();
+  });
+});

--- a/src/debouncer.ts
+++ b/src/debouncer.ts
@@ -1,0 +1,80 @@
+// A generic, keyed, trailing-edge debouncer.
+//
+// Calls made under the same key within the debounce window are collapsed: only the
+// most recently scheduled action for that key runs when the window goes quiet. Every
+// caller that scheduled under the key while it was pending receives the same shared
+// promise, resolving (or rejecting) with the result of that single run. Distinct keys
+// are fully independent.
+//
+// This lets a burst of HomeKit `onSet` events (a slider drag, a rapid multi-zone
+// toggle) coalesce into a single outgoing command while every awaiting handler still
+// gets a real result back.
+
+interface PendingEntry {
+  promise: Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+  action: () => Promise<unknown>;
+  timer: NodeJS.Timeout;
+}
+
+export class Debouncer {
+  private readonly entries = new Map<string, PendingEntry>();
+
+  constructor(private readonly delayMs: number) {}
+
+  // Schedule (or reschedule) an action under `key`. Restarts the quiet window and
+  // replaces any previously pending action for the key with this one (last write wins).
+  // Returns a promise shared by all callers scheduling under the key this window.
+  schedule<T>(key: string, action: () => Promise<T>): Promise<T> {
+    const existing = this.entries.get(key);
+    if (existing) {
+      clearTimeout(existing.timer);
+      existing.action = action as () => Promise<unknown>;
+      existing.timer = setTimeout(() => this.flush(key), this.delayMs);
+      return existing.promise as Promise<T>;
+    }
+
+    let resolve!: (value: unknown) => void;
+    let reject!: (reason: unknown) => void;
+    const promise = new Promise<unknown>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    const timer = setTimeout(() => this.flush(key), this.delayMs);
+    this.entries.set(key, { promise, resolve, reject, action: action as () => Promise<unknown>, timer });
+    return promise as Promise<T>;
+  }
+
+  // Whether a key currently has a pending (not yet fired) action.
+  isPending(key: string): boolean {
+    return this.entries.has(key);
+  }
+
+  // Run the pending action for `key` immediately, resolving/rejecting its shared promise.
+  // Safe to call when nothing is pending (no-op).
+  async flush(key: string): Promise<void> {
+    const entry = this.entries.get(key);
+    if (!entry) {
+      return;
+    }
+    clearTimeout(entry.timer);
+    this.entries.delete(key);
+    try {
+      const result = await entry.action();
+      entry.resolve(result);
+    } catch (error) {
+      entry.reject(error);
+    }
+  }
+
+  // Cancel every pending timer without running the actions. Their shared promises are
+  // rejected so awaiting callers do not hang. Intended for shutdown/teardown.
+  cancelAll(): void {
+    for (const [key, entry] of this.entries) {
+      clearTimeout(entry.timer);
+      this.entries.delete(key);
+      entry.reject(new Error(`Debounced action for "${key}" was cancelled`));
+    }
+  }
+}

--- a/src/hvac.ts
+++ b/src/hvac.ts
@@ -33,13 +33,14 @@ export class HvacUnit {
     private readonly hbUserStoragePath: string,
     readonly zonesFollowMaster = true,
     readonly zonesPushMaster = true,
-    readonly zonesAsHeaterCoolers = false) {
+    readonly zonesAsHeaterCoolers = false,
+    private readonly commandDebounceMs = 500) {
     this.name = name;
   }
 
   async actronQueApi(username: string, password: string, serialNo = '') {
     this.type = 'actronNeo';
-    this.apiInterface = new QueApi(username, password, this.name, this.log, this.hbUserStoragePath, serialNo);
+    this.apiInterface = new QueApi(username, password, this.name, this.log, this.hbUserStoragePath, serialNo, this.commandDebounceMs);
     await this.apiInterface.initializer();
     if (this.apiInterface.actronSerial) {
       this.serialNo = this.apiInterface.actronSerial;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -26,6 +26,7 @@ export class ActronQuePlatform implements DynamicPlatformPlugin {
   readonly zonesAsHeaterCoolers: boolean = false;
   readonly hardRefreshInterval: number = 60000;
   readonly softRefreshInterval: number = 5000;
+  readonly commandDebounceMs: number = 500;
   readonly maxCoolingTemp: number = 32;
   readonly minCoolingTemp: number = 20;
   readonly maxHeatingTemp: number = 26;
@@ -59,6 +60,10 @@ export class ActronQuePlatform implements DynamicPlatformPlugin {
     if (config['refreshInterval']) {
       this.hardRefreshInterval = config['refreshInterval'] * 1000;
       this.log.debug('Auto refresh interval set to seconds', this.hardRefreshInterval / 1000);
+    }
+    if (config['commandDebounceMs'] !== undefined) {
+      this.commandDebounceMs = config['commandDebounceMs'];
+      this.log.debug('Command debounce window set to ms', this.commandDebounceMs);
     }
     if (config['maxCoolingTemp']) {
       this.maxCoolingTemp = config['maxCoolingTemp'];
@@ -114,7 +119,7 @@ export class ActronQuePlatform implements DynamicPlatformPlugin {
     try {
       // Instantiate an instance of HvacUnit and connect the actronQueApi
       this.hvacInstance = new HvacUnit(this.clientName, this.log, this.api.user.storagePath(),
-        this.zonesFollowMaster, this.zonesPushMaster, this.zonesAsHeaterCoolers);
+        this.zonesFollowMaster, this.zonesPushMaster, this.zonesAsHeaterCoolers, this.commandDebounceMs);
       let hvacSerial = '';
       hvacSerial = await this.hvacInstance.actronQueApi(this.username, this.password, this.userProvidedSerialNo);
       // Make sure we have hvac master and zone data before adding devices

--- a/src/queApi.test.ts
+++ b/src/queApi.test.ts
@@ -1,4 +1,5 @@
 import QueApi from './queApi';
+import { validApiCommands } from './types';
 import { mockLogger } from './__mocks__/mockHomebridge';
 
 // Mock node-fetch
@@ -222,6 +223,94 @@ describe('QueApi', () => {
       await expect(
         api.manageApiRequest({ headers: { set: jest.fn() } } as never),
       ).rejects.toThrow('unhandled error');
+    });
+  });
+
+  describe('command pipeline', () => {
+    const MockRequest = jest.requireMock('node-fetch').Request;
+    // The request options passed to `new Request(url, options)` for the Nth send, in order.
+    const sentOptions = (index: number) => MockRequest.mock.calls[index][1];
+    const sentBody = (index: number) => JSON.parse(sentOptions(index).body).command;
+
+    const seedZones = (zones: boolean[]) => {
+      (api as unknown as { enabledZones: boolean[] }).enabledZones = zones;
+    };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      // Every POST acks successfully.
+      mockFetch.mockResolvedValue(createMockResponse(200, { type: 'ack' }));
+      // Fast debounce window for tests.
+      api = new QueApi('test@example.com', 'password123', 'test-client', mockLogger, '/test/storage', 'SERIAL123', 50);
+      // Only count Request constructions from here on (the constructor above builds none).
+      MockRequest.mockClear();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('coalesces a rapid multi-zone toggle into a single command carrying every change', async () => {
+      seedZones([false, false, false]);
+
+      const p0 = api.runCommand(validApiCommands.ZONE_ENABLE, 0, 0, 0);
+      const p1 = api.runCommand(validApiCommands.ZONE_ENABLE, 0, 0, 1);
+      const p2 = api.runCommand(validApiCommands.ZONE_ENABLE, 0, 0, 2);
+
+      await jest.advanceTimersByTimeAsync(50);
+      await Promise.all([p0, p1, p2]);
+
+      // One POST, not three, and it contains all three toggles merged together.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(sentBody(0)['UserAirconSettings.EnabledZones']).toEqual([true, true, true]);
+    });
+
+    it('does not re-read cloud zone state per toggle (no GET before the send)', async () => {
+      seedZones([false, false, false]);
+
+      const p = api.runCommand(validApiCommands.ZONE_ENABLE, 0, 0, 1);
+      await jest.advanceTimersByTimeAsync(50);
+      await p;
+
+      // Exactly one request total: the POST. The old code issued a GET per command first.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(MockRequest.mock.calls).toHaveLength(1);
+      expect(sentOptions(0).method).toBe('POST');
+    });
+
+    it('sends only the final value when a setpoint is changed rapidly', async () => {
+      const p0 = api.runCommand(validApiCommands.COOL_SET_POINT, 21, 0);
+      const p1 = api.runCommand(validApiCommands.COOL_SET_POINT, 22, 0);
+      const p2 = api.runCommand(validApiCommands.COOL_SET_POINT, 23, 0);
+
+      await jest.advanceTimersByTimeAsync(50);
+      await Promise.all([p0, p1, p2]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(sentBody(0)['UserAirconSettings.TemperatureSetpoint_Cool_oC']).toBe(23);
+    });
+
+    it('serialises distinct commands in the order they were issued', async () => {
+      const pZone = api.runCommand(validApiCommands.ON);
+      const pTemp = api.runCommand(validApiCommands.COOL_SET_POINT, 24, 0);
+
+      await jest.advanceTimersByTimeAsync(50);
+      await Promise.all([pZone, pTemp]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      // Power command was issued first, so it is sent first.
+      expect(sentBody(0)['UserAirconSettings.isOn']).toBe(true);
+      expect(sentBody(1)['UserAirconSettings.TemperatureSetpoint_Cool_oC']).toBe(24);
+    });
+
+    it('resolves every coalesced caller with the command result', async () => {
+      const p0 = api.runCommand(validApiCommands.COOL_SET_POINT, 21, 0);
+      const p1 = api.runCommand(validApiCommands.COOL_SET_POINT, 22, 0);
+
+      await jest.advanceTimersByTimeAsync(50);
+
+      await expect(p0).resolves.toBe('SUCCESS');
+      await expect(p1).resolves.toBe('SUCCESS');
     });
   });
 

--- a/src/queApi.ts
+++ b/src/queApi.ts
@@ -5,6 +5,11 @@ import { Schema, validate } from 'jtd';
 import { apiToken, tokenCollection, PowerState, validApiCommands, ZoneStatus, HvacStatus, CommandResult, ApiAccessError } from './types';
 import { AccessTokenSchema, BearerTokenSchema, SystemStatusSchema, AcSystemsSchema, CommandResponseSchema} from './schema';
 import { queApiCommands } from './queCommands';
+import { Debouncer } from './debouncer';
+
+// Builder signature shared by all non-zone-toggle commands in queApiCommands. Zone
+// enable/disable are handled separately via SET_ENABLED_ZONES against local state.
+type CommandBuilder = (coolTemp: number, heatTemp: number, zoneIndex: number, zones: boolean[]) => { command: object };
 
 // Defines an api interface for the Que cloud service
 export default class QueApi {
@@ -23,6 +28,18 @@ export default class QueApi {
   refreshToken: apiToken;
   bearerToken: apiToken;
 
+  // Locally-tracked authoritative copy of UserAirconSettings.EnabledZones. Seeded and
+  // reconciled by getStatus(), mutated by zone toggles. Building zone commands from this
+  // rather than re-reading (eventually-consistent) cloud state per toggle is what stops
+  // rapid zone toggles from clobbering each other.
+  private enabledZones: boolean[] = [];
+
+  // Serialises all outgoing commands so only one is in flight at a time, in order.
+  private commandChain: Promise<unknown> = Promise.resolve();
+
+  // Collapses bursts of same-target changes (slider drags, rapid toggles) into one send.
+  private readonly debouncer: Debouncer;
+
   constructor(
     private readonly username: string,
     private readonly password: string,
@@ -30,9 +47,11 @@ export default class QueApi {
     private readonly log: Logger,
     private readonly hbUserStoragePath: string,
     actronSerial = '',
+    commandDebounceMs = 500,
   ) {
     this.apiClientId = '';
     this.actronSerial = actronSerial;
+    this.debouncer = new Debouncer(commandDebounceMs);
 
     // check for existing client ID for given client name. If client name file does not exist then create one.
     // If client is new name then create a new unique ID.
@@ -356,6 +375,13 @@ export default class QueApi {
     const zoneEnabledState: object = response['lastKnownState']['UserAirconSettings']['EnabledZones'];
     const zoneCurrentStatus: ZoneStatus[] = [];
 
+    // Reconcile the local zone array from the cloud, but not while a zone toggle is still
+    // pending its debounced send - otherwise a refresh landing mid-toggle would discard
+    // the user's not-yet-sent intent.
+    if (!this.debouncer.isPending('zones')) {
+      this.enabledZones = [...(zoneEnabledState as boolean[])];
+    }
+
     // zone index number is based on the order in the returned array, we add the zone index to the
     // results as we need this to send commands later. The zone data is enclosed behind the serial number
     // we are also capturing the serial number of the sensor to be used later in the homebridge UUID generation
@@ -420,41 +446,95 @@ export default class QueApi {
     return currentStatus;
   }
 
-  async getZoneStatuses(): Promise<boolean[]> {
-    // TODO - Shouldn't need to make this call, data should be available already beacuse we've made the `getStatus` call.
-    // retrieves the full status of the aircon unit and all zones
-    const preparedRequest = new Request (this.queryUrl, {
-      method: 'GET',
-      headers: {'Authorization': `Bearer ${this.bearerToken.token}`, 'Accept': 'application/json'},
-    });
-
-    let response: object = {};
-    let valid_response = false;
-    try {
-      response = await this.manageApiRequest(preparedRequest);
-      valid_response = await this.validateSchema(SystemStatusSchema, response);
-    } catch (error) {
-      if (error instanceof Error) {
-        this.log.error(error.message);
-        // decided not to throw error in this case to see if we can silently recover
-      }
+  // Groups commands that target the same setting under a shared debounce key so a burst
+  // collapses to a single send. ON/OFF share a key (so flip-flops settle on the last),
+  // mode/fan variants share a key, and all zone enable/disable share 'zones' so toggles
+  // across zones coalesce into one array.
+  private commandKey(commandType: validApiCommands, zoneIndex: number): string {
+    switch (commandType) {
+      case validApiCommands.ON:
+      case validApiCommands.OFF:
+        return 'power';
+      case validApiCommands.CLIMATE_MODE_AUTO:
+      case validApiCommands.CLIMATE_MODE_COOL:
+      case validApiCommands.CLIMATE_MODE_FAN:
+      case validApiCommands.CLIMATE_MODE_HEAT:
+        return 'climateMode';
+      case validApiCommands.FAN_MODE_AUTO:
+      case validApiCommands.FAN_MODE_AUTO_CONT:
+      case validApiCommands.FAN_MODE_LOW:
+      case validApiCommands.FAN_MODE_LOW_CONT:
+      case validApiCommands.FAN_MODE_MEDIUM:
+      case validApiCommands.FAN_MODE_MEDIUM_CONT:
+      case validApiCommands.FAN_MODE_HIGH:
+      case validApiCommands.FAN_MODE_HIGH_CONT:
+        return 'fanMode';
+      case validApiCommands.COOL_SET_POINT:
+        return 'master:cool';
+      case validApiCommands.HEAT_SET_POINT:
+        return 'master:heat';
+      case validApiCommands.HEAT_COOL_SET_POINT:
+        return 'master:heatcool';
+      case validApiCommands.AWAY_MODE_ON:
+      case validApiCommands.AWAY_MODE_OFF:
+        return 'awayMode';
+      case validApiCommands.QUIET_MODE_ON:
+      case validApiCommands.QUIET_MODE_OFF:
+        return 'quietMode';
+      case validApiCommands.CONTROL_ALL_ZONES_ON:
+      case validApiCommands.CONTROL_ALL_ZONES_OFF:
+        return 'controlAllZones';
+      case validApiCommands.ZONE_ENABLE:
+      case validApiCommands.ZONE_DISABLE:
+        return 'zones';
+      case validApiCommands.ZONE_COOL_SET_POINT:
+        return `zone:${zoneIndex}:cool`;
+      case validApiCommands.ZONE_HEAT_SET_POINT:
+        return `zone:${zoneIndex}:heat`;
+      default:
+        return String(commandType);
     }
+  }
 
-    if ('apiAccessError' in response || !valid_response) {
-      // TODO: - Return meaningful error
-      this.log.error('Unable to retrieve zone status information');
-      return [];
+  // Builds the wire command. Evaluated at flush time, so zone commands snapshot the
+  // fully-merged local enabledZones array.
+  private buildCommandBody(commandType: validApiCommands, coolTemp: number, heatTemp: number, zoneIndex: number): { command: object } {
+    if (commandType === validApiCommands.ZONE_ENABLE || commandType === validApiCommands.ZONE_DISABLE) {
+      return queApiCommands.SET_ENABLED_ZONES(this.enabledZones);
     }
+    const builder = (queApiCommands as unknown as Record<string, CommandBuilder>)[commandType];
+    return builder(coolTemp, heatTemp, zoneIndex, this.enabledZones);
+  }
 
-    return response['lastKnownState']['UserAirconSettings']['EnabledZones'];
+  // Serialises tasks so only one runs at a time, in enqueue order. A task's failure never
+  // wedges the chain for later tasks.
+  private enqueue<T>(task: () => Promise<T>): Promise<T> {
+    const run = this.commandChain.then(() => task(), () => task());
+    this.commandChain = run.then(() => undefined, () => undefined);
+    return run;
   }
 
   // defaulting zoneIndex here to 255 as this should be an invalid value, but maybe i should do something different
   async runCommand(commandType: validApiCommands, coolTemp = 20.0, heatTemp = 20.0, zoneIndex = 255): Promise<CommandResult> {
-    // this function does what it says on the tin. Run the command issued to the system.
-    // all possible commands are stored in 'queCommands'
-    const currentStatus = await this.getZoneStatuses();
-    const command = queApiCommands[commandType](coolTemp, heatTemp, zoneIndex, currentStatus);
+    // Apply zone enable/disable intent to the local array immediately, before the send is
+    // scheduled, so a burst of toggles across zones merges into one command.
+    if (commandType === validApiCommands.ZONE_ENABLE) {
+      this.enabledZones[zoneIndex] = true;
+    } else if (commandType === validApiCommands.ZONE_DISABLE) {
+      this.enabledZones[zoneIndex] = false;
+    }
+
+    // Debounce/coalesce by target, then send through the serial queue. The returned
+    // promise resolves with the eventual command result for every coalesced caller.
+    const key = this.commandKey(commandType, zoneIndex);
+    return this.debouncer.schedule(key, () =>
+      this.enqueue(() => this.dispatchCommand(this.buildCommandBody(commandType, coolTemp, heatTemp, zoneIndex))),
+    );
+  }
+
+  // Performs the actual POST for an already-built command. Never throws: transport/parse
+  // problems are logged and mapped to a CommandResult so the serial chain stays healthy.
+  private async dispatchCommand(command: { command: object }): Promise<CommandResult> {
     this.log.debug(`attempting to send command:\n ${JSON.stringify(command)}`);
     const preparedRequest = new Request (this.commandUrl, {
       method: 'POST',
@@ -485,7 +565,7 @@ export default class QueApi {
       this.log.debug(`Command successful, 'ack' received from Actron Cloud:\n ${JSON.stringify(response['value'])}`);
       return CommandResult.SUCCESS;
     } else {
-      this.log.debug(`Command failed, NO 'ack' received from Actron Cloud:\n 
+      this.log.debug(`Command failed, NO 'ack' received from Actron Cloud:\n
       Command attempted: ${JSON.stringify(command)}\n
       API response: ${JSON.stringify(response)}`);
       return CommandResult.FAILURE;

--- a/src/queCommands.test.ts
+++ b/src/queCommands.test.ts
@@ -138,28 +138,16 @@ describe('queApiCommands', () => {
   });
 
   describe('Zone commands', () => {
-    it('ZONE_ENABLE should enable the specified zone', () => {
-      const currentZones = [true, false, false];
-      const result = queApiCommands.ZONE_ENABLE(0, 0, 1, currentZones);
+    it('SET_ENABLED_ZONES should send the full desired zone array', () => {
+      const result = queApiCommands.SET_ENABLED_ZONES([true, true, false]);
       expect(result.command['UserAirconSettings.EnabledZones']).toEqual([true, true, false]);
     });
 
-    it('ZONE_ENABLE should not mutate the original array', () => {
-      const currentZones = [true, false, false];
-      queApiCommands.ZONE_ENABLE(0, 0, 1, currentZones);
-      expect(currentZones).toEqual([true, false, false]);
-    });
-
-    it('ZONE_DISABLE should disable the specified zone', () => {
-      const currentZones = [true, true, true];
-      const result = queApiCommands.ZONE_DISABLE(0, 0, 1, currentZones);
-      expect(result.command['UserAirconSettings.EnabledZones']).toEqual([true, false, true]);
-    });
-
-    it('ZONE_DISABLE should not mutate the original array', () => {
-      const currentZones = [true, true, true];
-      queApiCommands.ZONE_DISABLE(0, 0, 1, currentZones);
-      expect(currentZones).toEqual([true, true, true]);
+    it('SET_ENABLED_ZONES should copy the array rather than reference the input', () => {
+      const zones = [true, false, false];
+      const result = queApiCommands.SET_ENABLED_ZONES(zones);
+      zones[1] = true;
+      expect(result.command['UserAirconSettings.EnabledZones']).toEqual([true, false, false]);
     });
 
     it('ZONE_COOL_SET_POINT should set zone cooling temperature', () => {
@@ -183,7 +171,7 @@ describe('queApiCommands', () => {
         queApiCommands.COOL_SET_POINT(24, 20),
         queApiCommands.AWAY_MODE_ON(),
         queApiCommands.QUIET_MODE_ON(),
-        queApiCommands.ZONE_ENABLE(0, 0, 0, [false]),
+        queApiCommands.SET_ENABLED_ZONES([false]),
       ];
 
       commands.forEach(cmd => {

--- a/src/queCommands.ts
+++ b/src/queCommands.ts
@@ -185,18 +185,13 @@ export const queApiCommands = {
       },
     }),
 
-  ZONE_ENABLE: (_coolTemp: number, _heatTemp: number, zoneIndex: number, currentZoneStatus: boolean[]) => (
+  // Sends the complete desired zone-enabled array in a single command. Zone toggles are
+  // coalesced against a locally-tracked array (see QueApi) rather than read-modify-writing
+  // cloud state per toggle, which previously let rapid toggles clobber each other.
+  SET_ENABLED_ZONES: (zones: boolean[]) => (
     {
       'command': {
-        ['UserAirconSettings.EnabledZones']: modifiedZoneStatuses(true, zoneIndex, currentZoneStatus),
-        'type': 'set-settings',
-      },
-    }),
-
-  ZONE_DISABLE: (_coolTemp: number, _heatTemp: number, zoneIndex: number, currentZoneStatus: boolean[]) => (
-    {
-      'command': {
-        ['UserAirconSettings.EnabledZones']: modifiedZoneStatuses(false, zoneIndex, currentZoneStatus),
+        ['UserAirconSettings.EnabledZones']: [...zones],
         'type': 'set-settings',
       },
     }),
@@ -217,15 +212,3 @@ export const queApiCommands = {
       },
     }),
 };
-
-//#region "Helper Functions"
-
-function modifiedZoneStatuses(status: boolean,
-  zoneIndex: number,
-  currentZoneStatus: boolean[]) { // read-only property with getter function (this is not the same thing as a "function-property")
-  const modifiedValues = [...currentZoneStatus];
-  modifiedValues[zoneIndex] = status;
-  return modifiedValues;
-}
-
-//#endregion "Helper Functions"


### PR DESCRIPTION
## Problem

Rapid successive changes from HomeKit did not all apply:

- Toggling several zones on/off in quick succession left only one (or some) applied.
- Dragging a temperature slider landed on a value *between* the start and the intended target.
- Turning the unit on/off right after a zone change applied inconsistently.

## Root causes

There are two distinct mechanisms, not one.

**1. Read-modify-write race on zones.** Every zone command rebuilt the entire `EnabledZones` array by first re-reading cloud state (`getZoneStatuses`), flipping one index, and POSTing the whole array. The Neo cloud is eventually consistent, so concurrent zone commands each read stale state and clobbered each other — last write wins, based on stale data. Because the toggles come from three different accessories, debouncing a single switch can't fix this.

**2. Unordered concurrent sends.** HomeKit fires an `onSet` for every intermediate slider value. Each became its own request with no ordering guarantee, so whichever the cloud processed last won — often not the final value.

## Changes

- **Local authoritative `EnabledZones`** in `QueApi`, seeded and reconciled by `getStatus()` and mutated locally by zone toggles. Zone commands are built from this instead of re-reading the cloud, and sent as a single `SET_ENABLED_ZONES` command. `getZoneStatuses()` and the per-zone `ZONE_ENABLE`/`ZONE_DISABLE` builders are removed in favour of it.
- **Serial command queue** — a promise chain so only one request is in flight at a time, in order. A failed send never wedges the chain.
- **Keyed trailing-edge debouncer** (`src/debouncer.ts`) — a burst on the same target coalesces into one send. Setpoints/modes are last-value-wins; zone toggles across accessories merge into one array. Every coalesced caller still receives the real command result.
- **`commandDebounceMs`** config option (default `500`) to tune the quiet window. Documented in the README and config schema.

## Behaviour

- Drag the master cool slider → one `COOL_SET_POINT(final)` after you stop.
- Toggle 3 zones fast → one `SET_ENABLED_ZONES([T,T,T])`; all three stick.
- Unit off right after a zone change → both apply, in order, without interleaving.

## Tests

- `debouncer.test.ts` — burst collapses to one run, latest action wins, keys isolated, errors don't wedge a key, `flush`/`cancelAll`.
- `queApi.test.ts` pipeline tests — zone coalescing (one merged POST, no GET), setpoint last-value-wins, serial ordering.
- Full suite: 233 passing. Lint and build clean.