### PR TITLE
Stop cloud read-back from clobbering just-set values

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ If you are not using the Homebridge config UI, you can add the following to your
         "zonesAsHeaterCoolers": false,
         "refreshInterval": 60,
         "commandDebounceMs": 500,
+        "stateSyncGraceMs": 90000,
         "debug": false,
         "deviceSerial": "",
         "maxCoolingTemp": 32,
@@ -83,6 +84,14 @@ If you are not using the Homebridge config UI, you can add the following to your
 When you make several changes in quick succession — dragging a temperature slider, toggling several zones on/off, or turning the unit on/off right after a zone change — the plugin waits briefly for you to finish and then sends a single, consolidated command. This prevents the changes from racing each other on the Neo cloud, which previously could leave only the last change applied or land a temperature somewhere between the start and target value.
 
 `commandDebounceMs` (default `500`) controls how long, in milliseconds, the plugin waits after your last change before sending. Lower values feel snappier; higher values coalesce more aggressively for very jittery bursts. Commands are also serialised, so they always apply to the unit in the order you made them.
+
+## State Sync Grace Window
+
+The Neo cloud's status endpoint is eventually consistent: for a short time after you change a setting, it can keep reporting the old value. Without protection a status refresh landing in that window would overwrite the value you just set, making it briefly bounce back to the old value (or the unit flick "off" right after you turn it on) until the cloud catches up.
+
+To prevent this, after you change a setting the plugin keeps trusting your value over status refreshes until the cloud reports the same value back, or until the grace window lapses, whichever comes first. If the cloud never agrees (for example the unit clamped or rejected the change), the guard expires and the next refresh is accepted as-is, so the display always self-heals.
+
+`stateSyncGraceMs` (default `90000`, i.e. 90 seconds) sets this window. Increase it if you still see values briefly bounce back after setting them. Decrease it if you want changes made elsewhere (such as on the physical wall controller) to be picked up sooner while you are also using HomeKit.
 
 ## Debug Logging
 
@@ -113,7 +122,17 @@ Note that zones cannot independently change the climate mode (heat/cool/auto) - 
 
 ## Error Handling
 
-[Your existing error handling information here]
+The plugin is built to degrade gracefully. When something goes wrong it favours keeping Homebridge running on the last known good state and recovering automatically once the problem clears, rather than crashing or leaving accessories in a broken state. The main behaviours are:
+
+- **Authentication and tokens.** Bearer tokens are refreshed automatically. If a request returns `401 Unauthorized`, the plugin fetches a fresh token and retries (a few times, with a short delay between attempts). If authentication keeps failing, or a `400` indicates a credential problem, the cached tokens are cleared so a Homebridge restart can re-pair cleanly. Tokens are persisted to disk, so a restart does not force a full re-login when they are still valid.
+- **Transient server errors (5xx) and gateway timeouts.** These are retried a few times with a delay. If they still fail, the plugin returns a handled error and continues using cached state instead of throwing, since these are usually temporary problems on the Neo service.
+- **Network outages.** Common connectivity errors (host unreachable, timeouts, DNS failures, and similar) are caught and logged as warnings. The plugin keeps serving the last known state and resumes normally once the connection returns.
+- **Invalid or incomplete API data.** Every response is validated against an expected schema. If the cloud returns data that fails validation, the plugin logs a warning and keeps the previous cached values rather than applying bad data.
+- **Command failures.** Every command reports whether it succeeded. If a command is rejected, the plugin re-reads the true state from the cloud and pushes that back to HomeKit so the display resyncs with reality. If the cloud is unreachable when sending, it logs a warning and keeps the last known state. Commands are serialised, so one failed send never blocks the ones after it.
+- **Master controller offline.** If the master controller loses its internet/WiFi connection, accessories keep showing their last known values. Attempts to change a setting while it is offline surface a communication error in the Home app instead of silently doing nothing.
+- **Eventual consistency.** Immediately after a change, the Neo cloud can briefly keep reporting the old value. The plugin trusts your change until the cloud agrees or the grace window lapses. See [State Sync Grace Window](#state-sync-grace-window) for details and the `stateSyncGraceMs` option.
+
+If you want to see exactly what the plugin is doing while diagnosing an issue, enable [Debug Logging](#debug-logging). The [Troubleshooting](#troubleshooting) section below lists the most common specific errors and what to do about them.
 
 ## Troubleshooting
 
@@ -131,7 +150,7 @@ Here are some common issues and their solutions:
 
 6. **Schema Validation Errors**: These occur when the API returns incomplete data. The plugin will attempt to continue operation using cached data.
 
-For more detailed information on error handling, please refer to the [Error Handling](#error-handling) section.
+For the general approach behind these behaviours, see the [Error Handling](#error-handling) section above. Enabling [Debug Logging](#debug-logging) can help pin down intermittent issues.
 
 ## Contributing
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -65,6 +65,13 @@
         "required": false,
         "default": 500
       },
+      "stateSyncGraceMs": {
+        "title": "State Sync Grace Window (ms)",
+        "description": "After you change a setting, how long to keep trusting your value over status refreshes from the Neo cloud, which can report the old value for a while (eventual consistency). The plugin stops waiting as soon as the cloud agrees, or when this window lapses, whichever comes first. Increase if values still briefly bounce back; decrease to pick up changes made elsewhere (e.g. the wall controller) sooner. Default 90000 (90 seconds).",
+        "type": "integer",
+        "required": false,
+        "default": 90000
+      },
       "debug": {
         "title": "Enable Debug Logging",
         "description": "Surfaces this plugin's detailed debug logs (command queueing, coalescing, API requests/responses) in the Homebridge log without needing to run all of Homebridge in debug mode. Useful for troubleshooting; leave off for normal use.",

--- a/src/hvac.test.ts
+++ b/src/hvac.test.ts
@@ -262,6 +262,55 @@ describe('HvacUnit', () => {
     });
   });
 
+  describe('optimistic write reconciliation (eventual consistency guard)', () => {
+    beforeEach(() => {
+      mockApiInterface.runCommand.mockResolvedValue(CommandResult.SUCCESS);
+    });
+
+    it('keeps a just-set setpoint when a status refresh still reports the old value', async () => {
+      await hvac.setCoolTemp(24);
+      expect(hvac.masterCoolingSetTemp).toBe(24);
+
+      // Cloud is eventually consistent and still reports the previous setpoint.
+      mockApiInterface.getStatus.mockResolvedValue(createMockHvacStatus({ masterCoolingSetTemp: 23 }));
+      await hvac.getStatus();
+
+      expect(hvac.masterCoolingSetTemp).toBe(24); // not bounced back to 23
+    });
+
+    it('accepts the cloud value once it agrees, then honours later external changes', async () => {
+      await hvac.setCoolTemp(24);
+
+      // Cloud catches up to our value -> guard clears.
+      mockApiInterface.getStatus.mockResolvedValue(createMockHvacStatus({ masterCoolingSetTemp: 24 }));
+      await hvac.getStatus();
+      expect(hvac.masterCoolingSetTemp).toBe(24);
+
+      // A genuine later change (e.g. from the wall controller) is now honoured.
+      mockApiInterface.getStatus.mockResolvedValue(createMockHvacStatus({ masterCoolingSetTemp: 21 }));
+      await hvac.getStatus();
+      expect(hvac.masterCoolingSetTemp).toBe(21);
+    });
+
+    it('takes the cloud value when there was no recent local write', async () => {
+      mockApiInterface.getStatus.mockResolvedValue(createMockHvacStatus({ masterCoolingSetTemp: 19 }));
+      await hvac.getStatus();
+      expect(hvac.masterCoolingSetTemp).toBe(19);
+    });
+
+    it('keeps power state set locally until the cloud reflects it (no brief flip to off)', async () => {
+      hvac.powerState = PowerState.OFF;
+      await hvac.setPowerStateOn();
+      expect(hvac.powerState).toBe(PowerState.ON);
+
+      // Cloud still reports OFF right after turning on.
+      mockApiInterface.getStatus.mockResolvedValue(createMockHvacStatus({ powerState: PowerState.OFF }));
+      await hvac.getStatus();
+
+      expect(hvac.powerState).toBe(PowerState.ON);
+    });
+  });
+
   describe('Away mode', () => {
     beforeEach(() => {
       mockApiInterface.runCommand.mockResolvedValue(CommandResult.SUCCESS);

--- a/src/hvac.ts
+++ b/src/hvac.ts
@@ -28,13 +28,22 @@ export class HvacUnit {
   zoneData: ZoneStatus[] = [];
   zoneInstances: HvacZone[] = [];
 
+  // The Neo cloud's "latest status" endpoint is eventually consistent: for a while after we
+  // send a command it keeps reporting the OLD value. Without protection, a periodic status
+  // refresh landing in that window overwrites the value we just set with stale data, so the
+  // UI bounces back to the old value until the cloud finally catches up. We record recent
+  // local writes and refuse to overwrite them from a status refresh until the cloud agrees
+  // (or the configurable grace period lapses). See reconcile()/markLocalWrite().
+  private pendingWrites = new Map<string, { value: unknown; expiresAt: number }>();
+
   constructor(name: string,
     private readonly log: Logger,
     private readonly hbUserStoragePath: string,
     readonly zonesFollowMaster = true,
     readonly zonesPushMaster = true,
     readonly zonesAsHeaterCoolers = false,
-    private readonly commandDebounceMs = 500) {
+    private readonly commandDebounceMs = 500,
+    private readonly stateSyncGraceMs = 90000) {
     this.name = name;
   }
 
@@ -50,6 +59,31 @@ export class HvacUnit {
     return this.serialNo;
   }
 
+  // Record that we just set `field` to `value` locally, so status refreshes won't overwrite
+  // it with stale cloud data until the cloud reflects the change (or the grace period lapses).
+  private markLocalWrite(field: string, value: unknown): void {
+    this.pendingWrites.set(field, { value, expiresAt: Date.now() + this.stateSyncGraceMs });
+  }
+
+  // Choose between a freshly-fetched cloud value and the current (possibly optimistic) one.
+  // Keeps the local value while a recent local write hasn't been reflected by the cloud yet;
+  // accepts the cloud value once it agrees, the grace period lapses, or there was no local write.
+  private reconcile<T>(field: string, cloudValue: T | undefined, current: T): T {
+    if (cloudValue === undefined) {
+      return current;
+    }
+    const pending = this.pendingWrites.get(field);
+    if (!pending) {
+      return cloudValue;
+    }
+    if (Date.now() > pending.expiresAt || cloudValue === pending.value) {
+      this.pendingWrites.delete(field);
+      return cloudValue;
+    }
+    this.log.debug(`Ignoring stale ${field} from status refresh (cloud: ${cloudValue}, keeping: ${current})`);
+    return current;
+  }
+
   async getStatus(): Promise<HvacStatus> {
     const status = await this.apiInterface.getStatus();
 
@@ -59,18 +93,20 @@ export class HvacUnit {
     }
 
     this.cloudConnected = (status.cloudConnected === undefined) ? this.cloudConnected : status.cloudConnected;
-    this.powerState = (status.powerState === undefined) ? this.powerState : status.powerState;
-    this.climateMode = (status.climateMode === undefined) ? this.climateMode : status.climateMode;
+    // User-settable fields go through reconcile() so a lagging cloud read can't bounce them back.
+    this.powerState = this.reconcile('powerState', status.powerState, this.powerState);
+    this.climateMode = this.reconcile('climateMode', status.climateMode, this.climateMode);
+    this.fanMode = this.reconcile('fanMode', status.fanMode, this.fanMode);
+    this.masterCoolingSetTemp = this.reconcile('masterCoolingSetTemp', status.masterCoolingSetTemp, this.masterCoolingSetTemp);
+    this.masterHeatingSetTemp = this.reconcile('masterHeatingSetTemp', status.masterHeatingSetTemp, this.masterHeatingSetTemp);
+    this.awayMode = this.reconcile('awayMode', status.awayMode, this.awayMode);
+    this.quietMode = this.reconcile('quietMode', status.quietMode, this.quietMode);
+    this.continuousFanMode = this.reconcile('continuousFanMode', status.continuousFanMode, this.continuousFanMode);
+    // Read-only telemetry always takes the latest cloud value.
     this.compressorMode = (status.compressorMode === undefined) ? this.compressorMode : status.compressorMode;
-    this.fanMode = (status.fanMode === undefined) ? this.fanMode : status.fanMode;
     this.fanRunning = (status.fanRunning === undefined) ? this.fanRunning : status.fanRunning;
-    this.masterCoolingSetTemp = (status.masterCoolingSetTemp === undefined) ? this.masterCoolingSetTemp : status.masterCoolingSetTemp;
-    this.masterHeatingSetTemp = (status.masterHeatingSetTemp === undefined) ? this.masterHeatingSetTemp : status.masterHeatingSetTemp;
     this.compressorChasingTemp = (status.compressorChasingTemp === undefined) ? this.compressorChasingTemp : status.compressorChasingTemp;
     this.compressorCurrentTemp = (status.compressorCurrentTemp === undefined) ? this.compressorCurrentTemp : status.compressorCurrentTemp;
-    this.awayMode = (status.awayMode === undefined) ? this.awayMode : status.awayMode;
-    this.quietMode = (status.quietMode === undefined) ? this.quietMode : status.quietMode;
-    this.continuousFanMode = (status.continuousFanMode === undefined) ? this.continuousFanMode : status.continuousFanMode;
     this.controlAllZones = (status.controlAllZones === undefined) ? this.controlAllZones : status.controlAllZones;
     this.masterCurrentTemp = (status.masterCurrentTemp === undefined) ? this.masterCurrentTemp : status.masterCurrentTemp;
     this.masterHumidity = (status.masterCurrentHumidity === undefined) ? this.masterHumidity : status.masterCurrentHumidity;
@@ -98,6 +134,7 @@ export class HvacUnit {
       const response = await this.apiInterface.runCommand(validApiCommands.ON);
       if (response === CommandResult.SUCCESS) {
         this.powerState = PowerState.ON;
+        this.markLocalWrite('powerState', PowerState.ON);
       } else if (response === CommandResult.FAILURE) {
         await this.getStatus();
         this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -118,6 +155,7 @@ export class HvacUnit {
       const response = await this.apiInterface.runCommand(validApiCommands.OFF);
       if (response === CommandResult.SUCCESS) {
         this.powerState = PowerState.OFF;
+        this.markLocalWrite('powerState', PowerState.OFF);
       } else if (response === CommandResult.FAILURE) {
         await this.getStatus();
         this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -133,6 +171,7 @@ export class HvacUnit {
     const response = await this.apiInterface.runCommand(validApiCommands.HEAT_SET_POINT, coolTemp, heatTemp);
     if (response === CommandResult.SUCCESS) {
       this.masterHeatingSetTemp = heatTemp;
+      this.markLocalWrite('masterHeatingSetTemp', heatTemp);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -147,6 +186,7 @@ export class HvacUnit {
     const response = await this.apiInterface.runCommand(validApiCommands.COOL_SET_POINT, coolTemp, heatTemp);
     if (response === CommandResult.SUCCESS) {
       this.masterCoolingSetTemp = coolTemp;
+      this.markLocalWrite('masterCoolingSetTemp', coolTemp);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -161,6 +201,8 @@ export class HvacUnit {
     if (response === CommandResult.SUCCESS) {
       this.masterCoolingSetTemp = coolTemp;
       this.masterHeatingSetTemp = heatTemp;
+      this.markLocalWrite('masterCoolingSetTemp', coolTemp);
+      this.markLocalWrite('masterHeatingSetTemp', heatTemp);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -174,6 +216,7 @@ export class HvacUnit {
     const response = await this.apiInterface.runCommand(validApiCommands.CLIMATE_MODE_AUTO);
     if (response === CommandResult.SUCCESS) {
       this.climateMode = ClimateMode.AUTO;
+      this.markLocalWrite('climateMode', ClimateMode.AUTO);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -187,6 +230,7 @@ export class HvacUnit {
     const response = await this.apiInterface.runCommand(validApiCommands.CLIMATE_MODE_COOL);
     if (response === CommandResult.SUCCESS) {
       this.climateMode = ClimateMode.COOL;
+      this.markLocalWrite('climateMode', ClimateMode.COOL);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -200,6 +244,7 @@ export class HvacUnit {
     const response = await this.apiInterface.runCommand(validApiCommands.CLIMATE_MODE_HEAT);
     if (response === CommandResult.SUCCESS) {
       this.climateMode = ClimateMode.HEAT;
+      this.markLocalWrite('climateMode', ClimateMode.HEAT);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -213,6 +258,7 @@ export class HvacUnit {
     const response = await this.apiInterface.runCommand(validApiCommands.CLIMATE_MODE_FAN);
     if (response === CommandResult.SUCCESS) {
       this.climateMode = ClimateMode.FAN;
+      this.markLocalWrite('climateMode', ClimateMode.FAN);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -226,6 +272,7 @@ export class HvacUnit {
     const response = await this.apiInterface.runCommand(this.continuousFanMode ? validApiCommands.FAN_MODE_AUTO_CONT : validApiCommands.FAN_MODE_AUTO);
     if (response === CommandResult.SUCCESS) {
       this.fanMode = this.continuousFanMode ? FanMode.AUTO_CONT : FanMode.AUTO;
+      this.markLocalWrite('fanMode', this.fanMode);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -239,6 +286,7 @@ export class HvacUnit {
     const response = await this.apiInterface.runCommand(this.continuousFanMode ? validApiCommands.FAN_MODE_LOW_CONT : validApiCommands.FAN_MODE_LOW);
     if (response === CommandResult.SUCCESS) {
       this.fanMode = this.continuousFanMode ? FanMode.LOW_CONT : FanMode.LOW;
+      this.markLocalWrite('fanMode', this.fanMode);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -252,6 +300,7 @@ export class HvacUnit {
     const response = await this.apiInterface.runCommand(this.continuousFanMode ? validApiCommands.FAN_MODE_MEDIUM_CONT : validApiCommands.FAN_MODE_MEDIUM);
     if (response === CommandResult.SUCCESS) {
       this.fanMode = this.continuousFanMode ? FanMode.MEDIUM_CONT : FanMode.MEDIUM;
+      this.markLocalWrite('fanMode', this.fanMode);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -265,6 +314,7 @@ export class HvacUnit {
     const response = await this.apiInterface.runCommand(this.continuousFanMode ? validApiCommands.FAN_MODE_HIGH_CONT : validApiCommands.FAN_MODE_HIGH);
     if (response === CommandResult.SUCCESS) {
       this.fanMode = this.continuousFanMode ? FanMode.HIGH_CONT : FanMode.HIGH;
+      this.markLocalWrite('fanMode', this.fanMode);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -278,6 +328,7 @@ export class HvacUnit {
     const response = await this.apiInterface.runCommand(validApiCommands.AWAY_MODE_ON);
     if (response === CommandResult.SUCCESS) {
       this.awayMode = true;
+      this.markLocalWrite('awayMode', true);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -291,6 +342,7 @@ export class HvacUnit {
     const response = await this.apiInterface.runCommand(validApiCommands.AWAY_MODE_OFF);
     if (response === CommandResult.SUCCESS) {
       this.awayMode = false;
+      this.markLocalWrite('awayMode', false);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -304,6 +356,7 @@ export class HvacUnit {
     const response = await this.apiInterface.runCommand(validApiCommands.QUIET_MODE_ON);
     if (response === CommandResult.SUCCESS) {
       this.quietMode = true;
+      this.markLocalWrite('quietMode', true);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -317,6 +370,7 @@ export class HvacUnit {
     const response = await this.apiInterface.runCommand(validApiCommands.QUIET_MODE_OFF);
     if (response === CommandResult.SUCCESS) {
       this.quietMode = false;
+      this.markLocalWrite('quietMode', false);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -339,6 +393,7 @@ export class HvacUnit {
     }
     if (response === CommandResult.SUCCESS) {
       this.continuousFanMode = true;
+      this.markLocalWrite('continuousFanMode', true);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);
@@ -362,6 +417,7 @@ export class HvacUnit {
     }
     if (response === CommandResult.SUCCESS) {
       this.continuousFanMode = false;
+      this.markLocalWrite('continuousFanMode', false);
     } else if (response === CommandResult.FAILURE) {
       await this.getStatus();
       this.log.error(`Failed to set master ${this.name}, refreshing master state from API`);

--- a/src/masterControllerAccessory.test.ts
+++ b/src/masterControllerAccessory.test.ts
@@ -266,10 +266,14 @@ describe('MasterControllerAccessory', () => {
   });
 
   describe('setHeatingThresholdTemperature', () => {
-    it('should call setHeatTemp and getStatus', async () => {
+    it('should call setHeatTemp', async () => {
       await accessory.setHeatingThresholdTemperature(22);
       expect(mockPlatform.hvacInstance.setHeatTemp).toHaveBeenCalledWith(22);
-      expect(mockPlatform.hvacInstance.getStatus).toHaveBeenCalled();
+    });
+
+    it('should not refresh status immediately (stale read would clobber the value just set)', async () => {
+      await accessory.setHeatingThresholdTemperature(22);
+      expect(mockPlatform.hvacInstance.getStatus).not.toHaveBeenCalled();
     });
   });
 
@@ -282,10 +286,14 @@ describe('MasterControllerAccessory', () => {
   });
 
   describe('setCoolingThresholdTemperature', () => {
-    it('should call setCoolTemp and getStatus', async () => {
+    it('should call setCoolTemp', async () => {
       await accessory.setCoolingThresholdTemperature(26);
       expect(mockPlatform.hvacInstance.setCoolTemp).toHaveBeenCalledWith(26);
-      expect(mockPlatform.hvacInstance.getStatus).toHaveBeenCalled();
+    });
+
+    it('should not refresh status immediately (stale read would clobber the value just set)', async () => {
+      await accessory.setCoolingThresholdTemperature(26);
+      expect(mockPlatform.hvacInstance.getStatus).not.toHaveBeenCalled();
     });
   });
 

--- a/src/masterControllerAccessory.ts
+++ b/src/masterControllerAccessory.ts
@@ -195,8 +195,10 @@ export class MasterControllerAccessory {
 
   async setHeatingThresholdTemperature(value: CharacteristicValue) {
     this.checkHvacComms();
+    // Note: no getStatus() here. setHeatTemp already updates local state, and the cloud's
+    // status endpoint lags behind the command, so refreshing now would clobber the value we
+    // just set with a stale reading. The periodic refresh reconciles once the cloud catches up.
     await this.platform.hvacInstance.setHeatTemp(value as number);
-    await this.platform.hvacInstance.getStatus();
     this.platform.log.debug('Set Master Target Heating Temperature -> ', value);
   }
 
@@ -207,8 +209,9 @@ export class MasterControllerAccessory {
 
   async setCoolingThresholdTemperature(value: CharacteristicValue) {
     this.checkHvacComms();
+    // Note: no getStatus() here (see setHeatingThresholdTemperature) - it would clobber the
+    // value we just set with a stale cloud reading.
     await this.platform.hvacInstance.setCoolTemp(value as number);
-    await this.platform.hvacInstance.getStatus();
     this.platform.log.debug('Set Master Target Cooling Temperature -> ', value);
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -32,6 +32,7 @@ export class ActronQuePlatform implements DynamicPlatformPlugin {
   readonly hardRefreshInterval: number = 60000;
   readonly softRefreshInterval: number = 5000;
   readonly commandDebounceMs: number = 500;
+  readonly stateSyncGraceMs: number = 90000;
   readonly maxCoolingTemp: number = 32;
   readonly minCoolingTemp: number = 20;
   readonly maxHeatingTemp: number = 26;
@@ -76,6 +77,10 @@ export class ActronQuePlatform implements DynamicPlatformPlugin {
     if (config['commandDebounceMs'] !== undefined) {
       this.commandDebounceMs = config['commandDebounceMs'];
       this.log.debug('Command debounce window set to ms', this.commandDebounceMs);
+    }
+    if (config['stateSyncGraceMs'] !== undefined) {
+      this.stateSyncGraceMs = config['stateSyncGraceMs'];
+      this.log.debug('State sync grace window set to ms', this.stateSyncGraceMs);
     }
     if (config['maxCoolingTemp']) {
       this.maxCoolingTemp = config['maxCoolingTemp'];
@@ -131,7 +136,7 @@ export class ActronQuePlatform implements DynamicPlatformPlugin {
     try {
       // Instantiate an instance of HvacUnit and connect the actronQueApi
       this.hvacInstance = new HvacUnit(this.clientName, this.log, this.api.user.storagePath(),
-        this.zonesFollowMaster, this.zonesPushMaster, this.zonesAsHeaterCoolers, this.commandDebounceMs);
+        this.zonesFollowMaster, this.zonesPushMaster, this.zonesAsHeaterCoolers, this.commandDebounceMs, this.stateSyncGraceMs);
       let hvacSerial = '';
       hvacSerial = await this.hvacInstance.actronQueApi(this.username, this.password, this.userProvidedSerialNo);
       // Make sure we have hvac master and zone data before adding devices


### PR DESCRIPTION
## Problem

After setting a value in HomeKit (temperature, power, mode), it could briefly bounce back to the old value, or the unit could flick "off" right after being turned on. The value eventually settled correctly, but it visibly bounced between states first.

## Root cause

The command was sent and **acked** by the unit, so the device had the right value. But the Neo cloud's `status/latest` endpoint is eventually consistent: for up to ~a minute it keeps reporting the *old* value. Two things then overwrote our correct local state with that stale read:

1. `setHeatingThresholdTemperature` / `setCoolingThresholdTemperature` ran an immediate `await getStatus()` right after setting, re-reading stale data and clobbering the value they'd just set. (No other setter did this.)
2. The periodic status refresh landing inside the consistency window did the same for power/mode/setpoints.

This is separate from, and was masked by, the earlier debounce work: only the final value went on the wire, but the read-back reverted it.

## Fix

- **Remove the redundant `getStatus()`** from the two master setpoint setters.
- **Eventual-consistency guard** in `HvacUnit`: when a user-settable field (power, mode, fan, setpoints, away, quiet) is set locally, status refreshes will not overwrite it until the cloud reports the same value back, or a grace window lapses. As soon as the cloud agrees the guard clears and genuine external changes (e.g. the wall controller) flow through normally.
- **Self-healing:** if the cloud never agrees (e.g. the unit clamped or rejected the change), the guard expires after the grace window and the next refresh is accepted as-is, so the display always converges on reality. The window is anchored to the write time, so a stuck value can never be masked for longer than one grace window.
- **Configurable** via `stateSyncGraceMs` (default `90000` = 90s). Increase if values still bounce; decrease to pick up external changes sooner.

## Docs

- Populate the README **Error Handling** section (was a `[placeholder]`) with the plugin's actual resilience behaviour (auth/token refresh, 5xx retries, network outages, schema validation, command failures, offline master, eventual consistency).
- Document `stateSyncGraceMs` in the config schema and README.

## Behaviour

Set 24 -> shows 24 -> stays 24. Turn on -> stays on. No bounce, no brief off.

## Tests

4 new reconciliation tests (stale read ignored, clears on match then honours external changes, no-write takes cloud value, power no-flip), updated master-accessory setter tests. Full suite: 245 passing, lint + typecheck + build clean.