### PR TITLE
Split debounce into separate setpoint and command windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ If you are not using the Homebridge config UI, you can add the following to your
         "zonesAsHeaterCoolers": false,
         "refreshInterval": 60,
         "commandDebounceMs": 500,
+        "setpointDebounceMs": 1000,
         "stateSyncGraceMs": 90000,
         "debug": false,
         "deviceSerial": "",
@@ -83,7 +84,12 @@ If you are not using the Homebridge config UI, you can add the following to your
 
 When you make several changes in quick succession — dragging a temperature slider, toggling several zones on/off, or turning the unit on/off right after a zone change — the plugin waits briefly for you to finish and then sends a single, consolidated command. This prevents the changes from racing each other on the Neo cloud, which previously could leave only the last change applied or land a temperature somewhere between the start and target value.
 
-`commandDebounceMs` (default `500`) controls how long, in milliseconds, the plugin waits after your last change before sending. Lower values feel snappier; higher values coalesce more aggressively for very jittery bursts. Commands are also serialised, so they always apply to the unit in the order you made them.
+There are two separate debounce windows, because the two kinds of input behave differently:
+
+- `commandDebounceMs` (default `500`) applies to discrete actions: turning the unit on/off, changing mode or fan, and toggling zones. These are single taps, so a shorter window keeps them feeling responsive while still batching a rapid multi-zone toggle into one send.
+- `setpointDebounceMs` (default `1000`) applies to temperature setpoints (master and zone). A slider drag fires a flood of intermediate values, so a longer window collapses the whole drag into a single command that carries only the final value.
+
+Lower values feel snappier; higher values coalesce more aggressively. Commands are also serialised, so they always apply to the unit in the order you made them.
 
 ## State Sync Grace Window
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -60,10 +60,17 @@
       },
       "commandDebounceMs": {
         "title": "Command Debounce Window (ms)",
-        "description": "How long to wait after your last change before sending it to the AC. Rapid changes (dragging a temperature slider, toggling several zones) are coalesced into a single command so they all apply. Lower feels snappier; higher coalesces more aggressively. Default 500.",
+        "description": "How long to wait after your last change before sending discrete commands (turning the unit on/off, changing mode or fan, toggling zones) to the AC. Rapid changes are coalesced into a single command so they all apply. Lower feels snappier; higher coalesces more aggressively (e.g. batching several quick zone toggles). Default 500.",
         "type": "integer",
         "required": false,
         "default": 500
+      },
+      "setpointDebounceMs": {
+        "title": "Setpoint Debounce Window (ms)",
+        "description": "Debounce window used specifically for temperature setpoints (master and zone). Dragging a slider fires many intermediate values, so this is usually set higher than the command window to collapse the whole drag into a single send with only the final value. Default 1000.",
+        "type": "integer",
+        "required": false,
+        "default": 1000
       },
       "stateSyncGraceMs": {
         "title": "State Sync Grace Window (ms)",

--- a/src/debouncer.test.ts
+++ b/src/debouncer.test.ts
@@ -47,6 +47,20 @@ describe('Debouncer', () => {
     await expect(p3).resolves.toBe(3);
   });
 
+  it('honours a per-call delay override', async () => {
+    const debouncer = new Debouncer(500);
+    const action = jest.fn().mockResolvedValue('done');
+
+    const promise = debouncer.schedule('key', action, 200);
+
+    jest.advanceTimersByTime(150);
+    expect(action).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(50); // reaches the 200ms override, not the 500ms default
+    await expect(promise).resolves.toBe('done');
+    expect(action).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps distinct keys independent', async () => {
     const debouncer = new Debouncer(500);
     const a = jest.fn().mockResolvedValue('a');

--- a/src/debouncer.ts
+++ b/src/debouncer.ts
@@ -25,13 +25,15 @@ export class Debouncer {
 
   // Schedule (or reschedule) an action under `key`. Restarts the quiet window and
   // replaces any previously pending action for the key with this one (last write wins).
+  // An optional `delayMs` overrides the default window for this key (a key always uses a
+  // consistent command type, so the delay stays stable across reschedules).
   // Returns a promise shared by all callers scheduling under the key this window.
-  schedule<T>(key: string, action: () => Promise<T>): Promise<T> {
+  schedule<T>(key: string, action: () => Promise<T>, delayMs: number = this.delayMs): Promise<T> {
     const existing = this.entries.get(key);
     if (existing) {
       clearTimeout(existing.timer);
       existing.action = action as () => Promise<unknown>;
-      existing.timer = setTimeout(() => this.flush(key), this.delayMs);
+      existing.timer = setTimeout(() => this.flush(key), delayMs);
       return existing.promise as Promise<T>;
     }
 
@@ -41,7 +43,7 @@ export class Debouncer {
       resolve = res;
       reject = rej;
     });
-    const timer = setTimeout(() => this.flush(key), this.delayMs);
+    const timer = setTimeout(() => this.flush(key), delayMs);
     this.entries.set(key, { promise, resolve, reject, action: action as () => Promise<unknown>, timer });
     return promise as Promise<T>;
   }

--- a/src/hvac.ts
+++ b/src/hvac.ts
@@ -43,13 +43,15 @@ export class HvacUnit {
     readonly zonesPushMaster = true,
     readonly zonesAsHeaterCoolers = false,
     private readonly commandDebounceMs = 500,
-    private readonly stateSyncGraceMs = 90000) {
+    private readonly stateSyncGraceMs = 90000,
+    private readonly setpointDebounceMs = 1000) {
     this.name = name;
   }
 
   async actronQueApi(username: string, password: string, serialNo = '') {
     this.type = 'actronNeo';
-    this.apiInterface = new QueApi(username, password, this.name, this.log, this.hbUserStoragePath, serialNo, this.commandDebounceMs);
+    this.apiInterface = new QueApi(username, password, this.name, this.log, this.hbUserStoragePath, serialNo,
+      this.commandDebounceMs, this.setpointDebounceMs);
     await this.apiInterface.initializer();
     if (this.apiInterface.actronSerial) {
       this.serialNo = this.apiInterface.actronSerial;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -32,6 +32,7 @@ export class ActronQuePlatform implements DynamicPlatformPlugin {
   readonly hardRefreshInterval: number = 60000;
   readonly softRefreshInterval: number = 5000;
   readonly commandDebounceMs: number = 500;
+  readonly setpointDebounceMs: number = 1000;
   readonly stateSyncGraceMs: number = 90000;
   readonly maxCoolingTemp: number = 32;
   readonly minCoolingTemp: number = 20;
@@ -77,6 +78,10 @@ export class ActronQuePlatform implements DynamicPlatformPlugin {
     if (config['commandDebounceMs'] !== undefined) {
       this.commandDebounceMs = config['commandDebounceMs'];
       this.log.debug('Command debounce window set to ms', this.commandDebounceMs);
+    }
+    if (config['setpointDebounceMs'] !== undefined) {
+      this.setpointDebounceMs = config['setpointDebounceMs'];
+      this.log.debug('Setpoint debounce window set to ms', this.setpointDebounceMs);
     }
     if (config['stateSyncGraceMs'] !== undefined) {
       this.stateSyncGraceMs = config['stateSyncGraceMs'];
@@ -136,7 +141,8 @@ export class ActronQuePlatform implements DynamicPlatformPlugin {
     try {
       // Instantiate an instance of HvacUnit and connect the actronQueApi
       this.hvacInstance = new HvacUnit(this.clientName, this.log, this.api.user.storagePath(),
-        this.zonesFollowMaster, this.zonesPushMaster, this.zonesAsHeaterCoolers, this.commandDebounceMs, this.stateSyncGraceMs);
+        this.zonesFollowMaster, this.zonesPushMaster, this.zonesAsHeaterCoolers,
+        this.commandDebounceMs, this.stateSyncGraceMs, this.setpointDebounceMs);
       let hvacSerial = '';
       hvacSerial = await this.hvacInstance.actronQueApi(this.username, this.password, this.userProvidedSerialNo);
       // Make sure we have hvac master and zone data before adding devices

--- a/src/queApi.test.ts
+++ b/src/queApi.test.ts
@@ -240,8 +240,8 @@ describe('QueApi', () => {
       jest.useFakeTimers();
       // Every POST acks successfully.
       mockFetch.mockResolvedValue(createMockResponse(200, { type: 'ack' }));
-      // Fast debounce window for tests.
-      api = new QueApi('test@example.com', 'password123', 'test-client', mockLogger, '/test/storage', 'SERIAL123', 50);
+      // Fast debounce windows for tests (command + setpoint).
+      api = new QueApi('test@example.com', 'password123', 'test-client', mockLogger, '/test/storage', 'SERIAL123', 50, 50);
       // Only count Request constructions from here on (the constructor above builds none).
       MockRequest.mockClear();
     });
@@ -300,6 +300,26 @@ describe('QueApi', () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
       // Power command was issued first, so it is sent first.
       expect(sentBody(0)['UserAirconSettings.isOn']).toBe(true);
+      expect(sentBody(1)['UserAirconSettings.TemperatureSetpoint_Cool_oC']).toBe(24);
+    });
+
+    it('uses separate debounce windows for setpoints and discrete commands', async () => {
+      // Command window 50ms, setpoint window 200ms.
+      api = new QueApi('test@example.com', 'password123', 'test-client', mockLogger, '/test/storage', 'SERIAL123', 50, 200);
+      MockRequest.mockClear();
+
+      const power = api.runCommand(validApiCommands.ON);
+      const temp = api.runCommand(validApiCommands.COOL_SET_POINT, 24, 0);
+
+      // After 50ms the discrete command has fired but the setpoint has not.
+      await jest.advanceTimersByTimeAsync(50);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(sentBody(0)['UserAirconSettings.isOn']).toBe(true);
+
+      // The setpoint fires once its longer window elapses.
+      await jest.advanceTimersByTimeAsync(150);
+      await Promise.all([power, temp]);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(sentBody(1)['UserAirconSettings.TemperatureSetpoint_Cool_oC']).toBe(24);
     });
 

--- a/src/queApi.ts
+++ b/src/queApi.ts
@@ -40,6 +40,7 @@ export default class QueApi {
   // Collapses bursts of same-target changes (slider drags, rapid toggles) into one send.
   private readonly debouncer: Debouncer;
   private readonly commandDebounceMs: number;
+  private readonly setpointDebounceMs: number;
 
   constructor(
     private readonly username: string,
@@ -49,12 +50,14 @@ export default class QueApi {
     private readonly hbUserStoragePath: string,
     actronSerial = '',
     commandDebounceMs = 500,
+    setpointDebounceMs = 1000,
   ) {
     this.apiClientId = '';
     this.actronSerial = actronSerial;
     this.commandDebounceMs = commandDebounceMs;
+    this.setpointDebounceMs = setpointDebounceMs;
     this.debouncer = new Debouncer(commandDebounceMs);
-    this.log.debug(`QueApi initialised with command debounce window of ${commandDebounceMs}ms`);
+    this.log.debug(`QueApi initialised with debounce windows: commands ${commandDebounceMs}ms, setpoints ${setpointDebounceMs}ms`);
 
     // check for existing client ID for given client name. If client name file does not exist then create one.
     // If client is new name then create a new unique ID.
@@ -501,6 +504,22 @@ export default class QueApi {
     }
   }
 
+  // Temperature setpoints come from continuous slider drags, which fire a flood of
+  // intermediate values, so they use their own (typically longer) debounce window to
+  // coalesce the whole drag. Everything else is a discrete tap and uses the shorter one.
+  private commandDelay(commandType: validApiCommands): number {
+    switch (commandType) {
+      case validApiCommands.COOL_SET_POINT:
+      case validApiCommands.HEAT_SET_POINT:
+      case validApiCommands.HEAT_COOL_SET_POINT:
+      case validApiCommands.ZONE_COOL_SET_POINT:
+      case validApiCommands.ZONE_HEAT_SET_POINT:
+        return this.setpointDebounceMs;
+      default:
+        return this.commandDebounceMs;
+    }
+  }
+
   // Builds the wire command. Evaluated at flush time, so zone commands snapshot the
   // fully-merged local enabledZones array.
   private buildCommandBody(commandType: validApiCommands, coolTemp: number, heatTemp: number, zoneIndex: number): { command: object } {
@@ -534,14 +553,15 @@ export default class QueApi {
     // Debounce/coalesce by target, then send through the serial queue. The returned
     // promise resolves with the eventual command result for every coalesced caller.
     const key = this.commandKey(commandType, zoneIndex);
+    const delay = this.commandDelay(commandType);
     if (this.debouncer.isPending(key)) {
       this.log.debug(`Coalescing ${commandType} into pending "${key}" command`);
     } else {
-      this.log.debug(`Queued ${commandType} under "${key}", sending in ~${this.commandDebounceMs}ms`);
+      this.log.debug(`Queued ${commandType} under "${key}", sending in ~${delay}ms`);
     }
     return this.debouncer.schedule(key, () =>
       this.enqueue(() => this.dispatchCommand(this.buildCommandBody(commandType, coolTemp, heatTemp, zoneIndex))),
-    );
+    delay);
   }
 
   // Performs the actual POST for an already-built command. Never throws: transport/parse


### PR DESCRIPTION
## Why

A single debounce window has to serve two very different kinds of input:

- **Temperature setpoints** come from a continuous slider drag, which fires a flood of intermediate values. They want a *longer* window to collapse the whole drag into one final-value send.
- **Discrete actions** (power, mode, fan, away, quiet, and zone toggles) are single taps. They want a *shorter* window so they feel responsive. Zone-toggle correctness is already guaranteed by the serial queue + local zone state, so debounce there is only about batching a rapid multi-zone toggle, not correctness.

With one global window, tuning it long enough to coalesce temperature drags made turning the unit on/off and flipping modes feel laggy.

## Change

Two independent windows, split along the setpoints-vs-discrete line (zones sit with the discrete actions, not with temperature):

- `commandDebounceMs` (default `500`) - power, mode, fan, away, quiet, zone toggles.
- `setpointDebounceMs` (default `1000`) - master and zone temperature setpoints.

The `Debouncer` now takes an optional per-call delay; `QueApi.commandDelay()` selects the window by command type, so each key debounces on its own clock. Plumbed platform -> HvacUnit -> QueApi, documented in the config schema and README, and the startup log reports both windows.

## Tests

- Setpoints and discrete commands fire on their own windows (discrete at 50ms, setpoint at 200ms).
- Debouncer honours a per-call delay override.
- Full suite: 247 passing, lint + typecheck + build clean.